### PR TITLE
Extract hardcoded model name to LLM_MODEL env var

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - RACK_ENV=development
       - LLM_ENDPOINT=http://host.docker.internal:1234 # Set your LLM endpoint
+      - LLM_MODEL=plamo-2-translate # Set your model name
       - TZ=Asia/Tokyo # Set your timezone
       # - SAVE_TRANSLATIONS=false # Uncomment to disable saving translations
     extra_hosts:

--- a/localingo/app.rb
+++ b/localingo/app.rb
@@ -17,6 +17,7 @@ set :public_folder, 'public'
 
 # 環境変数から設定を読み込む
 LLM_ENDPOINT = ENV['LLM_ENDPOINT'] || 'http://host.docker.internal:1234'
+LLM_MODEL = ENV['LLM_MODEL'] || 'plamo-2-translate'
 PDF_TRANSLATE_ENDPOINT = ENV['PDF_TRANSLATE_ENDPOINT'] || 'http://pdf2zh:11007'
 TRANSLATIONS_FILE = 'data/translations.json'
 PDF_DIR = 'data/pdfs'
@@ -141,7 +142,7 @@ post '/api/translate-text' do
         request = Net::HTTP::Post.new(uri.path)
         request['Content-Type'] = 'application/json'
         request.body = {
-          model: 'plamo-2-translate',
+          model: LLM_MODEL,
           messages: [{ role: 'user', content: prompt }],
           stop: ["<|plamo:op|>", "<|plamo:reserved:0x1E|>"],
           stream: true


### PR DESCRIPTION
- Add LLM_MODEL constant read from ENV with default 'plamo-2-translate'
- Replace hardcoded model name in app.rb with LLM_MODEL
- Add LLM_MODEL to compose.yml environment

Hermesに書かせたんだけれど便利だねこれ。